### PR TITLE
Import papaparse from NPM

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,9 @@ before_install:
   - npm config set spin false
   - npm install -g npm@4
   - npm --version
-  - npm install -g bower
 
 install:
   - npm install
-  - bower install
 
 script:
   # Usually, it's ok to finish the test scenario without reverting

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,1 +1,0 @@
-export default window.Papa;

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,6 +1,0 @@
-{
-  "predef": [
-    "console"
-  ],
-  "strict": false
-}

--- a/blueprints/ember-papaparse/index.js
+++ b/blueprints/ember-papaparse/index.js
@@ -1,9 +1,0 @@
-module.exports = {
-  description: 'Installation blueprint for ember-papaparse-shim',
-
-  normalizeEntityName: function() {},
-
-  afterInstall: function(options) {
-    return this.addBowerPackageToProject('papaparse', '~4.1.2');
-  }
-};

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "ember-papaparse",
-  "dependencies": {
-    "papaparse": "~4.1.2"
-  }
-}

--- a/index.js
+++ b/index.js
@@ -1,9 +1,31 @@
 /* eslint-env node */
 'use strict';
 
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
+
 module.exports = {
-  name: 'papaparse',
-  included: function(app) {
-    app.import(app.bowerDirectory + '/papaparse/papaparse.js');
-  }
+  name: 'ember-papaparse',
+
+  included(app) {
+    this._super.included.apply(this, arguments);
+
+    if (typeof app.import !== 'function' && app.app) {
+      app = app.app;
+    }
+    app.import('vendor/papaparse.js');
+    app.import('vendor/shims/papaparse.js');
+  },
+
+  treeForVendor(vendorTree) {
+    var papaparseTree = new Funnel(path.dirname(require.resolve('papaparse/papaparse.js')), {
+      files: ['papaparse.js'],
+    });
+    var trees = [papaparseTree];
+    if (vendorTree) {
+      trees.push(vendorTree);
+    }
+    return new MergeTrees(trees);
+  },
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.6.0"
+    "broccoli-funnel": "^2.0.1",
+    "broccoli-merge-trees": "^2.0.0",
+    "ember-cli-babel": "^6.6.0",
+    "papaparse": "^4.3.6"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/vendor/shims/papaparse.js
+++ b/vendor/shims/papaparse.js
@@ -1,0 +1,12 @@
+(function() {
+  function vendorModule() {
+    'use strict';
+
+    return {
+      'default': self['Papa'],
+      __esModule: true,
+    };
+  }
+
+  define('papaparse', [], vendorModule);
+})();


### PR DESCRIPTION
Instead of requiring addon users to add papaparse to thier bowser.json
we can just require it from NPM and provide it in this addon.

This shouldn't change the API for addon consumers at all, but there is no way to automate the removal of the package from bower.json so release notes should contain those instructions.